### PR TITLE
Correct two binding for primitive

### DIFF
--- a/color-picker.js
+++ b/color-picker.js
@@ -35,16 +35,19 @@ angular.module('ngColorPicker.directives', ['ngColorPicker.services'])
     .directive('ngColorPicker', function (ngColorPicker) {
 
         return {
-            scope: {
-                selected: '='
-            },
-            restrict: 'AE',
-            template: '<span ng-repeat="color in colors" ng-class="{selected: (color===selected)}" ng-click="pick(color)" style="background-color:{{color}};"></span>',
-            link: function (scope, element, attr, ngModel) {
+            restrict: 'E',
+            require: "ngModel",
+            template: '<span ng-repeat="color in colors" ng-class="{selected: selected(color)}" ng-click="pick(color)" style="background-color:{{color}};"></span>',
+            link: function (scope, element, attr, ngModelCtrl) {
+
                 scope.colors = ngColorPicker.colors();
-                scope.selected = scope.selected || scope.colors[0];
+
+                scope.selected = function (color) {
+                    return ngModelCtrl.$viewValue === color;
+                };
+
                 scope.pick = function (color) {
-                    scope.selected = color;
+                    ngModelCtrl.$setViewValue(color);
                 };
             }
         };

--- a/example.html
+++ b/example.html
@@ -6,9 +6,12 @@
     <link href="color-picker.css" media="all" rel="stylesheet" type="text/css">
 </head>
 <body ng-controller="MainCtrl">
-    <ng-color-picker selected="selectedColor"></ng-color-picker>
+    <ng-color-picker ng-model="selectedColor"></ng-color-picker>
+    {{selectedColor}}
     <br />
     <input type="text" ng-model="selectedColor" />
+    <br />
+    <button ng-click="changeColor('#B64926')">Two way binding</button>
     <script src="//ajax.googleapis.com/ajax/libs/angularjs/1.2.12/angular.min.js"></script>
     <script src="color-picker.js"></script>
     <script src="example.js"></script>

--- a/example.js
+++ b/example.js
@@ -11,5 +11,12 @@ angular.module('example', ['ngColorPicker.directives', 'ngColorPicker.services']
 
 })
 .controller('MainCtrl', ['$scope', function($scope) {
+
+	// nested values
     $scope.selectedColor = '#e1e1e1';
+
+    $scope.changeColor = function (color) {
+    	$scope.selectedColor = color;
+    };
+
 }]);


### PR DESCRIPTION
I realised that after the last pull request I'd introduced (or their always had been) some issues with the two way binding.

Angular has trouble when you two way bind primitives (anything that isn't an object or array). You can read a little bit about it here: https://github.com/angular/angular.js/wiki/Understanding-Scopes

So, In this pull request I've changed it to use the ng-model controller for setting the values correctly. I've also altered the directive to only work as an element as you can combine the template definition with non element directives.