### PR TITLE
Fix json validation error in bower.json

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -17,7 +17,7 @@
     "./example.html",
     "./example.js",
     "./index.php"
-  ]
+  ],
   "keywords": [
     "color-picker",
     "picker",


### PR DESCRIPTION
Missing comma in bower.json causes an `EMALFORMED Failed to read bower.json` error when installing from bower.